### PR TITLE
Added suppress_log

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Please read [Guard doc](http://github.com/guard/guard#readme) for more info abou
 
 ## Options
 
-The WEBrick guard has 3 options that you can set like this:
+The WEBrick guard has 6 options that you can set like this:
 
     guard 'webrick', :host => '127.0.0.1', :port => '35728', :docroot => 'public' do
       ...
@@ -50,6 +50,7 @@ Available options:
     :ssl => true             # default false
     :docroot => 'public'     # default current working directory
     :launchy => false        # default true
+    :suppress_log => true    # default false - suppresses command line log output
 
 ## Development
 

--- a/lib/guard/webrick.rb
+++ b/lib/guard/webrick.rb
@@ -13,11 +13,12 @@ module Guard
     def initialize(watchers=[], options={})
       super
       @options = {
-        :host       => '0.0.0.0',
-        :port       => 3000,
-        :ssl        => false,
-        :docroot    => Dir::pwd,
-        :launchy    => true
+        :host         => '0.0.0.0',
+        :port         => 3000,
+        :ssl          => false,
+        :docroot      => Dir::pwd,
+        :launchy      => true,
+        :suppress_log => false
       }.update(options)
     end
 
@@ -37,7 +38,8 @@ module Guard
           @options[:host],
           @options[:port].to_s,
           @options[:ssl].to_s,
-          @options[:docroot]
+          @options[:docroot],
+          @options[:suppress_log].to_s
         )
         wait_for_port
         if @options[:launchy]

--- a/lib/guard/webrick/server.rb
+++ b/lib/guard/webrick/server.rb
@@ -14,8 +14,6 @@ module Guard
           :DocumentRoot => File.expand_path(options[:docroot])
         }
 
-        puts options.inspect
-
         if options[:suppress_log]
           config.merge!({
             :Logger       => ::WEBrick::Log.new("/dev/null"),

--- a/lib/guard/webrick/version.rb
+++ b/lib/guard/webrick/version.rb
@@ -1,5 +1,5 @@
 module Guard
   module WEBrickVersion
-    VERSION = '0.1.5.dev'
+    VERSION = '0.1.4'
   end
 end


### PR DESCRIPTION
I'm using guard to run autotest with jasmine and casperjs - works great but the terminal logging was annoying me and there didn't appear to be a way to turn it off. This PR adds the :suppress_log option, which defaults to false to preserve existing behavior, but allows the user to turn logs off if they don't want them
