### PR TITLE
Support newer Guard versions

### DIFF
--- a/guard-webrick.gemspec
+++ b/guard-webrick.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = '>= 1.3.6'
   s.rubyforge_project = "guard-webrick"
 
-  s.add_dependency 'guard', '~> 1.0'
+  s.add_dependency 'guard', '>= 1.0'
   s.add_dependency 'spoon', '~> 0.0.1'
   s.add_dependency 'ffi'
   s.add_dependency 'launchy', '~> 2.1.0'


### PR DESCRIPTION
Guard is on version 2 now so this Gem doesn't work without this change. Once made it seems to work perfectly and all the tests pass.

I realise you may want a different change, feel free to critique this and I'll fix it up.

Would also be great if there could be a new Gem release so people can use this unmodified.

Great work here, thanks for the tool!
